### PR TITLE
[Chore] Pin Branch dependency to 0.24

### DIFF
--- a/mParticle-BranchMetrics.podspec
+++ b/mParticle-BranchMetrics.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-BranchMetrics/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.3.0'
-    s.ios.dependency 'Branch', '~> 0.24'
+    s.ios.dependency 'Branch', '0.24'
 end


### PR DESCRIPTION
Pins the Branch dependency to v0.24.0 as v0.24.1 requires Swift 4